### PR TITLE
Implement ZoneId option (+ update to gradle 5.5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = 'me.duncte123'
 archivesBaseName = 'loadingbar'
-version = "1.3.2_${getBuildNumber()}"
+version = "1.4.0_${getBuildNumber()}"
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -100,14 +100,5 @@ bintrayUpload {
 }
 
 def getBuildNumber() {
-    return System.getenv('GITHUB_ACTION') ?: getGitHash()
-}
-
-def getGitHash() {
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
+    return System.getenv('GITHUB_RUN_NUMBER') ?: 'dev'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = 'me.duncte123'
 archivesBaseName = 'loadingbar'
-version = "1.3.2"
+version = "1.3.2_${getBuildNumber()}"
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -99,11 +99,15 @@ bintrayUpload {
     onlyIf { System.getenv('BINTRAY_KEY') != null }
 }
 
-//def getGitHash() {
-//    def stdout = new ByteArrayOutputStream()
-//    exec {
-//        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-//        standardOutput = stdout
-//    }
-//    return stdout.toString().trim()
-//}
+def getBuildNumber() {
+    return System.getenv('GITHUB_ACTION') ?: getGitHash()
+}
+
+def getGitHash() {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = 'me.duncte123'
 archivesBaseName = 'loadingbar'
-version = "1.3.2_${getBuildNumber()}"
+version = "1.3.2"
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -99,15 +99,11 @@ bintrayUpload {
     onlyIf { System.getenv('BINTRAY_KEY') != null }
 }
 
-def getBuildNumber() {
-    return System.getenv('GITHUB_ACTION') ?: getGitHash()
-}
-
-def getGitHash() {
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
+//def getGitHash() {
+//    def stdout = new ByteArrayOutputStream()
+//    exec {
+//        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+//        standardOutput = stdout
+//    }
+//    return stdout.toString().trim()
+//}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,6 +16,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/duncte123/loadingbar/LoadingBar.java
+++ b/src/main/java/me/duncte123/loadingbar/LoadingBar.java
@@ -31,29 +31,42 @@ public class LoadingBar {
     }
 
     /**
-     * Returns the percentage of how much has passed from this year
+     * Returns the percentage of how much has passed from this year.
+     * <br>This uses the System's default ZoneId to determine the offset and has a precision of 16
      *
      * @return The percentage of how much has passed from this year
      */
     public static double getPercentage() {
         return getPercentage(16);
     }
-
+    
     /**
-     * Returns the percentage of how much has passed from this year
-     *
-     * @param precision The decimal points to display, min is 0 and max is 17
-     *
+     * Returns the percentage of how much has passed from this year.
+     * <br>This method uses the System's default ZoneId to determine the offset
+     * 
+     * @param precision The decimal points to display, min is 0 and max is 16
+     * 
      * @return The percentage of how much has passed from this year
      */
     public static double getPercentage(int precision) {
+        return getPercentage(precision, ZoneId.systemDefault());
+    }
+    
+    /**
+     * Returns the percentage of how much has passed from this year
+     *
+     * @param precision The decimal points to display, min is 0 and max is 16
+     * @param zoneId The ZoneId to use.
+     *
+     * @return The percentage of how much has passed from this year
+     */
+    public static double getPercentage(int precision, ZoneId zoneId) {
         final int finalPrecision = parsePrecision(precision);
 
         final LocalDateTime nowDateTime = LocalDateTime.now();
         final int currentYear = nowDateTime.getYear();
         final Instant instant = Instant.now(); //can be LocalDateTime
-        final ZoneId systemZone = ZoneId.systemDefault(); // my timezone
-        final ZoneOffset currentOffsetForMyZone = systemZone.getRules().getOffset(instant);
+        final ZoneOffset currentOffsetForMyZone = zoneId.getRules().getOffset(instant);
 
         final long now = nowDateTime.toEpochSecond(currentOffsetForMyZone);
 

--- a/src/main/java/me/duncte123/loadingbar/LoadingBar.java
+++ b/src/main/java/me/duncte123/loadingbar/LoadingBar.java
@@ -56,7 +56,7 @@ public class LoadingBar {
      * Returns the percentage of how much has passed from this year
      *
      * @param precision The decimal points to display, min is 0 and max is 16
-     * @param zoneId The ZoneId to use.
+     * @param zoneId The ZoneId to use. See {@link ZoneId} for more info
      *
      * @return The percentage of how much has passed from this year
      */


### PR DESCRIPTION
Allows to define a own ZoneId (e.g. "Europe/Paris" or "-05:00")

`getPercentage(int)` uses SystemDefault ZoneId (Same as before)